### PR TITLE
Vivid dev merge

### DIFF
--- a/src/device-provider-upower.c
+++ b/src/device-provider-upower.c
@@ -124,8 +124,6 @@ on_get_all_response (GObject * o, GAsyncResult * res, gpointer gdata)
       g_variant_lookup (dict, "TimeToFull", "x", &time_to_full);
       time = time_to_empty ? time_to_empty : time_to_full;
 
-
-
       if ((device = g_hash_table_lookup (p->devices, data->path)))
         {
           g_object_set (device, INDICATOR_POWER_DEVICE_KIND, (gint)kind,


### PR DESCRIPTION
This includes:

-Ignore "batt_therm" devices (fixes: ubports/ubports-touch#94)  This ignores "batt_therm" devices since they do not provide correct values. "batt_therm" is only used for temperature of the battery and seems to appear as a "battery" device in upower

- Add support for other flashlight sysfs paths

