### PR TITLE
Do not divide by battery size if percent less than 0.01

### DIFF
--- a/src/service.c
+++ b/src/service.c
@@ -1417,10 +1417,13 @@ create_totalled_battery_device (const GList * devices)
           const time_t t = indicator_power_device_get_time (walk);
           const UpDeviceState state = indicator_power_device_get_state (walk);
 
-          ++n_batteries;
 
           if (percent > 0.01)
-            sum_percent += percent;
+            {
+              sum_percent += percent;
+              ++n_batteries;
+            }
+            
 
           if (state == UP_DEVICE_STATE_CHARGING)
             {


### PR DESCRIPTION
This pr is working on Xiaomi redmi 5 plus, Moto G5 and other devices(halium-7.). But, please validate it on some devices with more than one batteries, it should works.