### PR TITLE
add switch support

### DIFF
--- a/src/flashlight.c
+++ b/src/flashlight.c
@@ -27,11 +27,14 @@
 #define QCOM_ENABLE "255"
 #define QCOM_DISABLE "0"
 
-const size_t qcom_sysfs_size = 4;
+const size_t qcom_sysfs_size = 10;
 const size_t qcom_switch_size = 1;
 
 const char* const qcom_sysfs[] = {"/sys/class/leds/torch-light/brightness", "/sys/class/leds/led:flash_torch/brightness",
-                                  "/sys/class/leds/led:torch_0/brightness", "/sys/class/leds/led:torch_1/brightness"};
+                                  "/sys/class/leds/led:torch_0/brightness", "/sys/class/leds/led:torch_1/brightness",
+                                  "/sys/class/leds/torch-light0/brightness", "/sys/class/leds/torch-light1/brightness",
+                                  "/sys/class/leds/torch0/brightness", "/sys/class/leds/torch1/brightness",
+                                  "/sys/class/leds/flash0/brightness", "/sys/class/leds/flash1/brightness"};
 const char* const qcom_switch[] = {"/sys/class/leds/led:switch/brightness"};
 
 char* flash_sysfs_path = NULL;

--- a/src/flashlight.c
+++ b/src/flashlight.c
@@ -28,7 +28,8 @@
 #define QCOM_DISABLE "0"
 
 const size_t qcom_sysfs_size = 2;
-const char* const qcom_sysfs[] = {"/sys/class/leds/torch-light/brightness", "/sys/class/leds/led:flash_torch/brightness"};
+const char* const qcom_sysfs[] = {"/sys/class/leds/torch-light/brightness", "/sys/class/leds/led:flash_torch/brightness",
+                                  "/sys/class/leds/led:torch_0/brightness", "/sys/class/leds/led:torch_1/brightness"};
 
 char* flash_sysfs_path = NULL;
 gboolean activated = 0;


### PR DESCRIPTION
and add more flashlight sysfs paths...
on the Oneplus3, in order to enable the torch, we need to do this:
```
echo 255 > /sys/class/leds/led\:torch_0/brightness 
echo 255 > /sys/class/leds/led\:switch/brightness
```
and to disable it:
```
echo 0 > /sys/class/leds/led\:torch_1/brightness 
echo 0 > /sys/class/leds/led\:switch/brightness
```
so this PR add the support