### PR TITLE
flashlight: Add support for simpler sysfs toggles

### DIFF
--- a/src/flashlight.c
+++ b/src/flashlight.c
@@ -37,8 +37,9 @@ const char* const qcom_sysfs[] = {"/sys/class/leds/torch-light/brightness",
                                   "/sys/class/leds/torch-light1/brightness"};
 const char* qcom_torch_enable = "/sys/class/leds/led:switch/brightness";
 
-const size_t simple_sysfs_size = 1;
-const char* const simple_sysfs[] = {"/sys/class/flashlight_core/flashlight/flashlight_torch"};
+const size_t simple_sysfs_size = 2;
+const char* const simple_sysfs[] = {"/sys/class/flashlight_core/flashlight/flashlight_torch",
+                                    "/sys/class/leds/white:flash/brightness"};
 
 char* flash_sysfs_path = NULL;
 enum TorchType torch_type = SIMPLE;

--- a/src/flashlight.c
+++ b/src/flashlight.c
@@ -26,6 +26,8 @@
 
 #define QCOM_ENABLE "255"
 #define QCOM_DISABLE "0"
+#define SIMPLE_ENABLE "1"
+#define SIMPLE_DISABLE "0"
 
 const size_t qcom_sysfs_size = 5;
 const char* const qcom_sysfs[] = {"/sys/class/leds/torch-light/brightness",
@@ -33,10 +35,13 @@ const char* const qcom_sysfs[] = {"/sys/class/leds/torch-light/brightness",
                                   "/sys/class/leds/flashlight/brightness",
                                   "/sys/class/leds/torch-light0/brightness",
                                   "/sys/class/leds/torch-light1/brightness"};
-
 const char* qcom_torch_enable = "/sys/class/leds/led:switch/brightness";
 
+const size_t simple_sysfs_size = 1;
+const char* const simple_sysfs[] = {"/sys/class/flashlight_core/flashlight/flashlight_torch"};
+
 char* flash_sysfs_path = NULL;
+enum TorchType torch_type = SIMPLE;
 gboolean activated = 0;
 
 int
@@ -45,6 +50,13 @@ set_sysfs_path()
   for (size_t i = 0; i < qcom_sysfs_size; i++) {
     if (access(qcom_sysfs[i], F_OK ) != -1){
         flash_sysfs_path = qcom_sysfs[i];
+        torch_type = QCOM;
+        return 1;
+    }
+  }
+  for (size_t i = 0; i < simple_sysfs_size; i++) {
+    if (access(simple_sysfs[i], F_OK ) != -1){
+        flash_sysfs_path = simple_sysfs[i];
         return 1;
     }
   }
@@ -57,22 +69,12 @@ flashlight_activated()
   return activated;
 }
 
-void
-toggle_flashlight_action(GAction *action,
-                         GVariant *parameter G_GNUC_UNUSED,
-                         gpointer data G_GNUC_UNUSED)
+int
+toggle_flashlight_action_qcom()
 {
-  GVariant *state;
   FILE *fd1 = NULL, *fd2 = NULL;
-
   int needs_enable;
 
-  if (!set_sysfs_path())
-    return;
-
-  state = g_action_get_state(action);
-  activated = g_variant_get_boolean(state);
-  g_variant_unref(state);
   fd1 = fopen(flash_sysfs_path, "w");
   if (fd1 != NULL) {
     needs_enable = access(qcom_torch_enable, F_OK ) != -1;
@@ -91,8 +93,47 @@ toggle_flashlight_action(GAction *action,
     fclose(fd1);
     if (fd2 !=NULL)
       fclose(fd2);
-    g_action_change_state(action, g_variant_new_boolean(!activated));
+    return 1;
   }
+  return 0;
+}
+
+int
+toggle_flashlight_action_simple()
+{
+  FILE *fd = NULL;
+
+  fd = fopen(flash_sysfs_path, "w");
+  if (fd != NULL) {
+    fprintf(fd, activated ? SIMPLE_DISABLE : SIMPLE_ENABLE);
+    fclose(fd);
+    return 1;
+  }
+  return 0;
+}
+
+void
+toggle_flashlight_action(GAction *action,
+                         GVariant *parameter G_GNUC_UNUSED,
+                         gpointer data G_GNUC_UNUSED)
+{
+  GVariant *state;
+  int toggled;
+
+  if (!set_sysfs_path())
+    return;
+
+  state = g_action_get_state(action);
+  activated = g_variant_get_boolean(state);
+  g_variant_unref(state);
+
+  if (torch_type == QCOM)
+    toggled = toggle_flashlight_action_qcom();
+  else
+    toggled = toggle_flashlight_action_simple();
+
+  if (toggled)
+    g_action_change_state(action, g_variant_new_boolean(!activated));
 }
 
 int

--- a/src/flashlight.h
+++ b/src/flashlight.h
@@ -24,6 +24,12 @@
 
 G_BEGIN_DECLS
 
+int
+toggle_flashlight_action_qcom();
+
+int
+toggle_flashlight_action_simple();
+
 void
 toggle_flashlight_action(GAction *action,
                          GVariant *parameter G_GNUC_UNUSED,
@@ -34,6 +40,9 @@ flashlight_supported();
 
 gboolean
 flashlight_activated();
+
+enum
+TorchType { SIMPLE = 1, QCOM };
 
 G_END_DECLS
 


### PR DESCRIPTION
This is used by the Volla Phone (Helio P23 / MT6763) for example.

**HELP WANTED:** What `sysfs` paths do legacy / other existing ported MTK devices use for flashlight control? We could add support for them in this PR as well :)