### PR TITLE
Ignore batteries with unknown technology when merging

### DIFF
--- a/.crossbuilder/post_deploy
+++ b/.crossbuilder/post_deploy
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+restart indicator-power

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+indicator-power (12.10.9+ubports0) xenial; urgency=medium
+
+  * Ignore batteries with unknown technology when merging
+  * Sort batteries with known technology before others
+
+ -- Maciej Sopyło <me@klh.io>  Mon, 22 Nov 2021 20:00:38 +0100
+
 indicator-power (12.10.8+ubports2) xenial; urgency=medium
 
   * Try to detect if flash needs to be enabled (latched) separately 

--- a/po/indicator-power.pot
+++ b/po/indicator-power.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-05-03 16:56-0400\n"
+"POT-Creation-Date: 2021-11-22 21:18+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,159 +17,6 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
-
-#. TRANSLATORS: system power cord
-#: ../src/device.c:524
-msgid "AC Adapter"
-msgstr ""
-
-#. TRANSLATORS: laptop primary battery
-#: ../src/device.c:528 ../src/service.c:443
-msgid "Battery"
-msgstr ""
-
-#. TRANSLATORS: battery-backed AC power source
-#: ../src/device.c:532
-msgid "UPS"
-msgstr ""
-
-#. TRANSLATORS: a monitor is a device to measure voltage and current
-#: ../src/device.c:536
-msgid "Monitor"
-msgstr ""
-
-#. TRANSLATORS: wireless mice with internal batteries
-#: ../src/device.c:540
-msgid "Mouse"
-msgstr ""
-
-#. TRANSLATORS: wireless keyboard with internal battery
-#: ../src/device.c:544
-msgid "Keyboard"
-msgstr ""
-
-#. TRANSLATORS: portable device
-#: ../src/device.c:548
-msgid "PDA"
-msgstr ""
-
-#. TRANSLATORS: cell phone (mobile...)
-#: ../src/device.c:552
-msgid "Cell phone"
-msgstr ""
-
-#. TRANSLATORS: media player, mp3 etc
-#: ../src/device.c:556
-msgid "Media player"
-msgstr ""
-
-#. TRANSLATORS: tablet device
-#: ../src/device.c:560
-msgid "Tablet"
-msgstr ""
-
-#. TRANSLATORS: tablet device
-#: ../src/device.c:564
-msgid "Computer"
-msgstr ""
-
-#. TRANSLATORS: unknown device
-#: ../src/device.c:568
-msgid "Unknown"
-msgstr ""
-
-#: ../src/device.c:608
-#, c-format
-msgid "estimating…"
-msgstr ""
-
-#: ../src/device.c:612
-#, c-format
-msgid "unknown"
-msgstr ""
-
-#. TRANSLATORS: H:MM (hours, minutes) to charge the battery. Example: "1:30 to charge"
-#: ../src/device.c:641
-#, c-format
-msgid "%0d:%02d to charge"
-msgstr ""
-
-#. TRANSLATORS: H:MM (hours, minutes) to discharge the battery. Example: "1:30 left"
-#: ../src/device.c:646
-#, c-format
-msgid "%0d:%02d left"
-msgstr ""
-
-#. TRANSLATORS: "X (hour,hours) Y (minute,minutes) to charge" the battery.
-#. Example: "1 hour 10 minutes to charge"
-#: ../src/device.c:681
-#, c-format
-msgid "%d %s %d %s to charge"
-msgstr ""
-
-#: ../src/device.c:682 ../src/device.c:700
-msgid "hour"
-msgid_plural "hours"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../src/device.c:683 ../src/device.c:690 ../src/device.c:701
-#: ../src/device.c:708
-msgid "minute"
-msgid_plural "minutes"
-msgstr[0] ""
-msgstr[1] ""
-
-#. TRANSLATORS: "Y (minute,minutes) to charge" the battery.
-#. Example: "59 minutes to charge"
-#: ../src/device.c:689
-#, c-format
-msgid "%d %s to charge"
-msgstr ""
-
-#. TRANSLATORS: "X (hour,hours) Y (minute,minutes) left" until the battery's empty.
-#. Example: "1 hour 10 minutes left"
-#: ../src/device.c:699
-#, c-format
-msgid "%d %s %d %s left"
-msgstr ""
-
-#. TRANSLATORS: "Y (minute,minutes) left" until the battery's empty.
-#. Example: "59 minutes left"
-#: ../src/device.c:707
-#, c-format
-msgid "%d %s left"
-msgstr ""
-
-#. TRANSLATORS: example: "battery (charged)"
-#: ../src/device.c:764
-#, c-format
-msgid "%s (charged)"
-msgstr ""
-
-#. TRANSLATORS: example: "battery (time remaining)"
-#: ../src/device.c:781
-#, c-format
-msgid "%s (%s)"
-msgstr ""
-
-#. TRANSLATORS: after the icon, a time-remaining string + battery %. Example: "(0:59, 33%)"
-#: ../src/device.c:853
-#, c-format
-msgid "(%s, %.0lf%%)"
-msgstr ""
-
-#. TRANSLATORS: after the icon, a time-remaining string Example: "(0:59)"
-#: ../src/device.c:858
-#, c-format
-msgid "(%s)"
-msgstr ""
-
-#. TRANSLATORS: after the icon, a battery %. Example: "(33%)"
-#: ../src/device.c:863
-#, c-format
-msgid "(%.0lf%%)"
-msgstr ""
 
 #: ../src/notifier.c:286
 msgid "Battery Low"
@@ -192,34 +39,187 @@ msgstr ""
 msgid "Battery settings"
 msgstr ""
 
-#: ../src/service.c:568
+#. TRANSLATORS: laptop primary battery
+#: ../src/service.c:458 ../src/device.c:556
+msgid "Battery"
+msgstr ""
+
+#: ../src/service.c:583
 msgid "Charge level"
 msgstr ""
 
-#: ../src/service.c:636
+#: ../src/service.c:651
 msgid "Show Time in Menu Bar"
 msgstr ""
 
-#: ../src/service.c:640
+#: ../src/service.c:655
 msgid "Show Percentage in Menu Bar"
 msgstr ""
 
-#: ../src/service.c:644
+#: ../src/service.c:659
 msgid "Power Settings…"
 msgstr ""
 
-#: ../src/service.c:670
+#: ../src/service.c:685
 msgid "Adjust brightness automatically"
 msgstr ""
 
-#: ../src/service.c:678
+#: ../src/service.c:693
 msgid "Flashlight"
 msgstr ""
 
-#: ../src/service.c:684
+#: ../src/service.c:699
 msgid "Warning: Heavy use can damage the LED!"
 msgstr ""
 
-#: ../src/service.c:690
+#: ../src/service.c:705
 msgid "Battery settings…"
+msgstr ""
+
+#. TRANSLATORS: system power cord
+#: ../src/device.c:552
+msgid "AC Adapter"
+msgstr ""
+
+#. TRANSLATORS: battery-backed AC power source
+#: ../src/device.c:560
+msgid "UPS"
+msgstr ""
+
+#. TRANSLATORS: a monitor is a device to measure voltage and current
+#: ../src/device.c:564
+msgid "Monitor"
+msgstr ""
+
+#. TRANSLATORS: wireless mice with internal batteries
+#: ../src/device.c:568
+msgid "Mouse"
+msgstr ""
+
+#. TRANSLATORS: wireless keyboard with internal battery
+#: ../src/device.c:572
+msgid "Keyboard"
+msgstr ""
+
+#. TRANSLATORS: portable device
+#: ../src/device.c:576
+msgid "PDA"
+msgstr ""
+
+#. TRANSLATORS: cell phone (mobile...)
+#: ../src/device.c:580
+msgid "Cell phone"
+msgstr ""
+
+#. TRANSLATORS: media player, mp3 etc
+#: ../src/device.c:584
+msgid "Media player"
+msgstr ""
+
+#. TRANSLATORS: tablet device
+#: ../src/device.c:588
+msgid "Tablet"
+msgstr ""
+
+#. TRANSLATORS: tablet device
+#: ../src/device.c:592
+msgid "Computer"
+msgstr ""
+
+#. TRANSLATORS: unknown device
+#: ../src/device.c:596
+msgid "Unknown"
+msgstr ""
+
+#: ../src/device.c:636
+#, c-format
+msgid "estimating…"
+msgstr ""
+
+#: ../src/device.c:640
+#, c-format
+msgid "unknown"
+msgstr ""
+
+#. TRANSLATORS: H:MM (hours, minutes) to charge the battery. Example: "1:30 to charge"
+#: ../src/device.c:669
+#, c-format
+msgid "%0d:%02d to charge"
+msgstr ""
+
+#. TRANSLATORS: H:MM (hours, minutes) to discharge the battery. Example: "1:30 left"
+#: ../src/device.c:674
+#, c-format
+msgid "%0d:%02d left"
+msgstr ""
+
+#. TRANSLATORS: "X (hour,hours) Y (minute,minutes) to charge" the battery.
+#. Example: "1 hour 10 minutes to charge"
+#: ../src/device.c:709
+#, c-format
+msgid "%d %s %d %s to charge"
+msgstr ""
+
+#: ../src/device.c:710 ../src/device.c:728
+msgid "hour"
+msgid_plural "hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/device.c:711 ../src/device.c:718 ../src/device.c:729
+#: ../src/device.c:736
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] ""
+msgstr[1] ""
+
+#. TRANSLATORS: "Y (minute,minutes) to charge" the battery.
+#. Example: "59 minutes to charge"
+#: ../src/device.c:717
+#, c-format
+msgid "%d %s to charge"
+msgstr ""
+
+#. TRANSLATORS: "X (hour,hours) Y (minute,minutes) left" until the battery's empty.
+#. Example: "1 hour 10 minutes left"
+#: ../src/device.c:727
+#, c-format
+msgid "%d %s %d %s left"
+msgstr ""
+
+#. TRANSLATORS: "Y (minute,minutes) left" until the battery's empty.
+#. Example: "59 minutes left"
+#: ../src/device.c:735
+#, c-format
+msgid "%d %s left"
+msgstr ""
+
+#. TRANSLATORS: example: "battery (charged)"
+#: ../src/device.c:792
+#, c-format
+msgid "%s (charged)"
+msgstr ""
+
+#. TRANSLATORS: example: "battery (time remaining)"
+#: ../src/device.c:809
+#, c-format
+msgid "%s (%s)"
+msgstr ""
+
+#. TRANSLATORS: after the icon, a time-remaining string + battery %. Example: "(0:59, 33%)"
+#: ../src/device.c:881
+#, c-format
+msgid "(%s, %.0lf%%)"
+msgstr ""
+
+#. TRANSLATORS: after the icon, a time-remaining string Example: "(0:59)"
+#: ../src/device.c:886
+#, c-format
+msgid "(%s)"
+msgstr ""
+
+#. TRANSLATORS: after the icon, a battery %. Example: "(33%)"
+#: ../src/device.c:891
+#, c-format
+msgid "(%.0lf%%)"
 msgstr ""

--- a/src/device-provider-upower.c
+++ b/src/device-provider-upower.c
@@ -109,6 +109,7 @@ on_get_all_response (GObject * o, GAsyncResult * res, gpointer gdata)
     {
       guint32 kind = 0;
       guint32 state = 0;
+      guint32 technology = 0;
       gdouble percentage = 0;
       gint64 time_to_empty = 0;
       gint64 time_to_full = 0;
@@ -120,6 +121,7 @@ on_get_all_response (GObject * o, GAsyncResult * res, gpointer gdata)
 
       g_variant_lookup (dict, "Type", "u", &kind);
       g_variant_lookup (dict, "State", "u", &state);
+      g_variant_lookup (dict, "Technology", "u", &technology);
       g_variant_lookup (dict, "Percentage", "d", &percentage);
       g_variant_lookup (dict, "TimeToEmpty", "x", &time_to_empty);
       g_variant_lookup (dict, "TimeToFull", "x", &time_to_full);
@@ -130,6 +132,7 @@ on_get_all_response (GObject * o, GAsyncResult * res, gpointer gdata)
         {
           g_object_set (device, INDICATOR_POWER_DEVICE_KIND, (gint)kind,
                                 INDICATOR_POWER_DEVICE_STATE, (gint)state,
+                                INDICATOR_POWER_DEVICE_TECHNOLOGY, (gint)technology,
                                 INDICATOR_POWER_DEVICE_OBJECT_PATH, data->path,
                                 INDICATOR_POWER_DEVICE_PERCENTAGE, percentage,
                                 INDICATOR_POWER_DEVICE_TIME, time,
@@ -142,6 +145,7 @@ on_get_all_response (GObject * o, GAsyncResult * res, gpointer gdata)
                                                kind,
                                                percentage,
                                                state,
+                                               technology,
                                                (time_t)time,
                                                power_supply);
 

--- a/src/device.h
+++ b/src/device.h
@@ -45,6 +45,7 @@ typedef struct _IndicatorPowerDevicePrivate IndicatorPowerDevicePrivate;
 #define INDICATOR_POWER_DEVICE_PERCENTAGE   "percentage"
 #define INDICATOR_POWER_DEVICE_TIME         "time"
 #define INDICATOR_POWER_DEVICE_POWER_SUPPLY "power-supply"
+#define INDICATOR_POWER_DEVICE_TECHNOLOGY   "technology"
 
 typedef enum
 {
@@ -77,6 +78,19 @@ typedef enum
 }
 UpDeviceState;
 
+typedef enum
+{
+  UP_DEVICE_TECHNOLOGY_UNKNOWN,
+  UP_DEVICE_TECHNOLOGY_LIION,
+  UP_DEVICE_TECHNOLOGY_LIPOL,
+  UP_DEVICE_TECHNOLOGY_FEPO,
+  UP_DEVICE_TECHNOLOGY_PB,
+  UP_DEVICE_TECHNOLOGY_NICD,
+  UP_DEVICE_TECHNOLOGY_NIMH,
+  UP_DEVICE_TECHNOLOGY_LAST
+}
+UpDeviceTechnology;
+
 
 /**
  * IndicatorPowerDeviceClass:
@@ -108,6 +122,7 @@ IndicatorPowerDevice* indicator_power_device_new (const gchar    * object_path,
                                                   UpDeviceKind     kind,
                                                   gdouble          percentage,
                                                   UpDeviceState    state,
+                                                  UpDeviceTechnology technology,
                                                   time_t           time,
                                                   gboolean         power_supply);
 
@@ -120,6 +135,7 @@ IndicatorPowerDevice* indicator_power_device_new_from_variant (GVariant * varian
 
 UpDeviceKind  indicator_power_device_get_kind              (const IndicatorPowerDevice * device);
 UpDeviceState indicator_power_device_get_state             (const IndicatorPowerDevice * device);
+UpDeviceTechnology indicator_power_device_get_technology   (const IndicatorPowerDevice * device);
 const gchar * indicator_power_device_get_object_path       (const IndicatorPowerDevice * device);
 gdouble       indicator_power_device_get_percentage        (const IndicatorPowerDevice * device);
 time_t        indicator_power_device_get_time              (const IndicatorPowerDevice * device);

--- a/src/service.c
+++ b/src/service.c
@@ -174,6 +174,7 @@ device_compare_func (gconstpointer ga, gconstpointer gb)
 {
   int ret;
   int state;
+  int technology;
   const IndicatorPowerDevice * a = ga;
   const IndicatorPowerDevice * b = gb;
   const gboolean a_power_supply = indicator_power_device_get_power_supply (a);
@@ -184,6 +185,8 @@ device_compare_func (gconstpointer ga, gconstpointer gb)
   const gdouble b_percentage = indicator_power_device_get_percentage (b);
   const time_t a_time = indicator_power_device_get_time (a);
   const time_t b_time = indicator_power_device_get_time (b);
+  const int a_technology = indicator_power_device_get_technology (a);
+  const int b_technology = indicator_power_device_get_technology (b);  
 
   ret = 0;
 
@@ -197,6 +200,17 @@ device_compare_func (gconstpointer ga, gconstpointer gb)
         {
           ret = 1;
         }
+    }
+
+  technology = UP_DEVICE_TECHNOLOGY_UNKNOWN;
+  if (!ret && (a_technology != b_technology) &&
+      (a_technology == technology || b_technology == technology))
+    {
+      if (a_technology != technology) { /* a has a defined battery technology */
+        ret = -1;
+      } else {
+        ret = 1;
+      }
     }
 
   state = UP_DEVICE_STATE_DISCHARGING;
@@ -1416,7 +1430,12 @@ create_totalled_battery_device (const GList * devices)
           const double percent = indicator_power_device_get_percentage (walk);
           const time_t t = indicator_power_device_get_time (walk);
           const UpDeviceState state = indicator_power_device_get_state (walk);
+          const UpDeviceTechnology technology = indicator_power_device_get_technology (walk);
 
+          if (technology == UP_DEVICE_TECHNOLOGY_UNKNOWN)
+            {
+              continue;
+            }
 
           if (percent > 0.01)
             {
@@ -1474,6 +1493,7 @@ create_totalled_battery_device (const GList * devices)
                                            UP_DEVICE_KIND_BATTERY,
                                            percent,
                                            state,
+                                           UP_DEVICE_TECHNOLOGY_UNKNOWN,
                                            time_left,
                                            TRUE);
     }

--- a/src/testing.c
+++ b/src/testing.c
@@ -301,6 +301,7 @@ indicator_power_testing_init (IndicatorPowerTesting * self)
                                                UP_DEVICE_KIND_BATTERY,
                                                50.0,
                                                UP_DEVICE_STATE_DISCHARGING,
+                                               UP_DEVICE_TECHNOLOGY_LIPOL,
                                                60*30,
                                                TRUE);
 

--- a/tests/test-notify.cc
+++ b/tests/test-notify.cc
@@ -235,6 +235,7 @@ TEST_F(NotifyFixture, PercentageToLevel)
                                              UP_DEVICE_KIND_BATTERY,
                                              50.0,
                                              UP_DEVICE_STATE_DISCHARGING,
+                                             UP_DEVICE_TECHNOLOGY_LIPOL,
                                              30,
                                              TRUE);
 
@@ -314,6 +315,7 @@ TEST_F(NotifyFixture, LevelsDuringBatteryDrain)
                                              UP_DEVICE_KIND_BATTERY,
                                              50.0,
                                              UP_DEVICE_STATE_DISCHARGING,
+                                             UP_DEVICE_TECHNOLOGY_LIPOL,
                                              30,
                                              TRUE);
 
@@ -387,6 +389,7 @@ TEST_F(NotifyFixture, EventsThatChangeNotifications)
                                              UP_DEVICE_KIND_BATTERY,
                                              percent_low + 1.0,
                                              UP_DEVICE_STATE_DISCHARGING,
+                                             UP_DEVICE_TECHNOLOGY_LIPOL,
                                              30,
                                              TRUE);
 

--- a/tests/test-service.cc
+++ b/tests/test-service.cc
@@ -71,12 +71,12 @@ class IndicatorTest : public ::testing::Test
       ac_device = indicator_power_device_new (
         "/org/freedesktop/UPower/devices/line_power_AC",
         UP_DEVICE_KIND_LINE_POWER,
-        0.0, UP_DEVICE_STATE_UNKNOWN, 0);
+        0.0, UP_DEVICE_STATE_UNKNOWN, UP_DEVICE_TECHNOLOGY_UNKNOWN, 0);
 
       battery_device = indicator_power_device_new (
         "/org/freedesktop/UPower/devices/battery_BAT0",
         UP_DEVICE_KIND_BATTERY,
-        52.871712, UP_DEVICE_STATE_DISCHARGING, 8834);
+        52.871712, UP_DEVICE_STATE_DISCHARGING, UP_DEVICE_TECHNOLOGY_LIPOL, 8834);
     }
 
     virtual void TearDown()
@@ -248,7 +248,7 @@ TEST_F(IndicatorTest, AvoidChargingBatteriesWithZeroSecondsLeft)
   IndicatorPowerDevice * bad_battery_device  = indicator_power_device_new (
     "/org/freedesktop/UPower/devices/battery_BAT0",
     UP_DEVICE_KIND_BATTERY,
-    53, UP_DEVICE_STATE_CHARGING, 0);
+    53, UP_DEVICE_STATE_CHARGING, UP_DEVICE_TECHNOLOGY_LIPOL, 0);
 
   GSList * devices = NULL;
   devices = g_slist_append (devices, battery_device);
@@ -271,34 +271,34 @@ TEST_F(IndicatorTest, OtherDevices)
 
   devices = g_slist_append (devices, indicator_power_device_new (
     "/org/freedesktop/UPower/devices/mouse", UP_DEVICE_KIND_MOUSE,
-    0, UP_DEVICE_STATE_UNKNOWN, 0));
+    0, UP_DEVICE_STATE_UNKNOWN, UP_DEVICE_TECHNOLOGY_UNKNOWN, 0));
   devices = g_slist_append (devices, indicator_power_device_new (
     "/org/freedesktop/UPower/devices/ups", UP_DEVICE_KIND_UPS,
-    0, UP_DEVICE_STATE_UNKNOWN, 0));
+    0, UP_DEVICE_STATE_UNKNOWN, UP_DEVICE_TECHNOLOGY_UNKNOWN, 0));
   devices = g_slist_append (devices, indicator_power_device_new (
     "/org/freedesktop/UPower/devices/keyboard", UP_DEVICE_KIND_KEYBOARD,
-    0, UP_DEVICE_STATE_UNKNOWN, 0));
+    0, UP_DEVICE_STATE_UNKNOWN, UP_DEVICE_TECHNOLOGY_UNKNOWN, 0));
   devices = g_slist_append (devices, indicator_power_device_new (
     "/org/freedesktop/UPower/devices/pda", UP_DEVICE_KIND_PDA,
-    0, UP_DEVICE_STATE_UNKNOWN, 0));
+    0, UP_DEVICE_STATE_UNKNOWN, UP_DEVICE_TECHNOLOGY_UNKNOWN, 0));
   devices = g_slist_append (devices, indicator_power_device_new (
     "/org/freedesktop/UPower/devices/phone", UP_DEVICE_KIND_PHONE,
-    0, UP_DEVICE_STATE_UNKNOWN, 0));
+    0, UP_DEVICE_STATE_UNKNOWN, UP_DEVICE_TECHNOLOGY_UNKNOWN, 0));
   devices = g_slist_append (devices, indicator_power_device_new (
     "/org/freedesktop/UPower/devices/monitor", UP_DEVICE_KIND_MONITOR,
-    0, UP_DEVICE_STATE_UNKNOWN, 0));
+    0, UP_DEVICE_STATE_UNKNOWN, UP_DEVICE_TECHNOLOGY_UNKNOWN, 0));
   devices = g_slist_append (devices, indicator_power_device_new (
     "/org/freedesktop/UPower/devices/media_player", UP_DEVICE_KIND_MEDIA_PLAYER,
-    0, UP_DEVICE_STATE_UNKNOWN, 0));
+    0, UP_DEVICE_STATE_UNKNOWN, UP_DEVICE_TECHNOLOGY_UNKNOWN, 0));
   devices = g_slist_append (devices, indicator_power_device_new (
     "/org/freedesktop/UPower/devices/tablet", UP_DEVICE_KIND_TABLET,
-    0, UP_DEVICE_STATE_UNKNOWN, 0));
+    0, UP_DEVICE_STATE_UNKNOWN, UP_DEVICE_TECHNOLOGY_UNKNOWN, 0));
   devices = g_slist_append (devices, indicator_power_device_new (
     "/org/freedesktop/UPower/devices/computer", UP_DEVICE_KIND_COMPUTER,
-    0, UP_DEVICE_STATE_UNKNOWN, 0));
+    0, UP_DEVICE_STATE_UNKNOWN, UP_DEVICE_TECHNOLOGY_UNKNOWN, 0));
   devices = g_slist_append (devices, indicator_power_device_new (
     "/org/freedesktop/UPower/devices/unknown", UP_DEVICE_KIND_UNKNOWN,
-    0, UP_DEVICE_STATE_UNKNOWN, 0));
+    0, UP_DEVICE_STATE_UNKNOWN, UP_DEVICE_TECHNOLOGY_UNKNOWN, 0));
 
   indicator_power_set_devices (power, devices);
 


### PR DESCRIPTION
Also sort batteries with known technology before others.

In theory this should make the unusable batteries on some Android phones get lower priority, since they report unknown battery technology. For my Pixel 2 XL this fixed the indicator.

If there are devices out there that don't report the battery technology for their main battery, but do for some other UPower device, then this will break the indicator for them (seems unlikely, but you never know).

I also added a post-deploy script to restart the service, makes development a bit quicker (let me know if this should be removed from the PR or moved to a separate commit).

Testing results so far:
- Pixel 2 XL `taimen` **(fix)**
- Galaxy Note 4 910F `trlte` **(fix)**
- Cosmo Communicator **(no change, working)**
- Pinephone **(no change, working)**
- Redmi Note 7 Pro `violet` **(fix)**
- Redmi Note 9 `merlin` **(fix, weird lag until switches to charging)**
- BQ Aquaris E5 HD `vegetahd` **(no change, not working)**